### PR TITLE
Add PHP8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,32 +12,28 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
-    - php: 7.3
-      env:
-        - DEPS=lowest
-    - php: 7.3
-      env:
-        - DEPS=latest
     - php: 7.4
       env:
         - DEPS=lowest
     - php: 7.4
       env:
         - DEPS=latest
+    - php: nightly
+      env:
+        - DEPS=lowest
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - php: nightly
+      env:
+        - DEPS=latest
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-permissions-rbac": "^2.5.1 || ^3.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-authorization": "^1.0",
@@ -38,7 +38,9 @@
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-servicemanager": "^3.3",
-        "phpunit/phpunit": "^7.5.20 || ^8.5.2"
+        "phpunit/phpunit": "^9.3",
+        "phpspec/prophecy": "^1.12",
+        "phpspec/prophecy-phpunit": "^2.0"
     },
     "conflict": {
         "container-interop/container-interop": "<1.2.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
     <testsuites>
@@ -9,9 +9,9 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage>
+        <include>
             <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/test/LaminasRbacFactoryTest.php
+++ b/test/LaminasRbacFactoryTest.php
@@ -15,11 +15,14 @@ use Mezzio\Authorization\Rbac\LaminasRbac;
 use Mezzio\Authorization\Rbac\LaminasRbacAssertionInterface;
 use Mezzio\Authorization\Rbac\LaminasRbacFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 
 class LaminasRbacFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 

--- a/test/LaminasRbacTest.php
+++ b/test/LaminasRbacTest.php
@@ -17,11 +17,14 @@ use Mezzio\Authorization\Rbac\LaminasRbacAssertionInterface;
 use Mezzio\Router\Route;
 use Mezzio\Router\RouteResult;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ServerRequestInterface;
 
 class LaminasRbacTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var Rbac|ObjectProphecy */
     private $rbac;
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation |no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description
Closes #5 

- [X] Modify `composer.json` to provide support for PHP 8.0 by adding the constraint `~8.0.0`
- [X] Modify `composer.json` to drop support for PHP less than 7.3
- [X] Modify `composer.json` to implement phpunit 9.3 which supports PHP 7.3+
- [X] Modify `.travis.yml` to ignore platform requirements when installing composer dependencies (simply add `--ignore-platform-reqs` to `COMPOSER_ARGS` env variable)
- [X] Modify `.travis.yml` to add PHP 8.0 to the matrix (_NOTE_: Do not allow failures as PHP 8.0 has a feature freeze since 2020-08-04!)
